### PR TITLE
🚢 Use builtin container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 
 	"name": "tp4-exercises",
 
-	"image": "ghcr.io/albertomercurio/ubuntu-python-julia:release",
+	"image": "ghcr.io/matteosecli/tp4-exercises:docker",
 
 	// Configure tool-specific properties.
 	"customizations": {


### PR DESCRIPTION
The idea here is to streamline the environment and make it easier to maintain.

The Docker container is built in the `docker` branch, and used as a base image for the `devcontainer`.

- [x] Still have to test thoroughly the container in this branch.